### PR TITLE
feat: show profile pic & title

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
       <div class="schedule__container">
         <div id="meeting_info" class="meeting__info">
           <img class="logo" src="https://d3v0px0pttie1i.cloudfront.net/uploads/organization/logo/3296535/895ca01b.png" alt="Rise8"/>
-          <div id="info_block" class="info_block" ></div>
+          <div id="info_block" class="info_block"></div>
         </div>
         <div id="container" class="container">
               <span style="position: relative;">

--- a/src/appsscript.json
+++ b/src/appsscript.json
@@ -8,11 +8,6 @@
         "serviceId": "calendar"
       },
       {
-        "userSymbol": "AdminDirectory",
-        "version": "directory_v1",
-        "serviceId": "admin"
-      },
-      {
         "userSymbol": "Drive",
         "version": "v2",
         "serviceId": "drive"
@@ -21,6 +16,11 @@
         "userSymbol": "Sheets",
         "version": "v4",
         "serviceId": "sheets"
+      },
+      {
+        "userSymbol": "People",
+        "version": "v1",
+        "serviceId": "peopleapi"
       }
     ]
   },

--- a/src/backend/CalendarFunctions.js
+++ b/src/backend/CalendarFunctions.js
@@ -3,10 +3,7 @@ function getMeetingInfo(type) {
   type?.toLowerCase()
 
   const meeting = getMeetingDetails(type)
-  const host = getRandomHost(meeting)
-
-  meeting.host = host.email
-  meeting.displayName = host.displayName
+  meeting.host = getRandomHost(meeting)
 
   delete meeting.hosts
 
@@ -27,7 +24,7 @@ function preview(meeting, startString) {
   let workWindow = { start, end }
   let busyTimes = getFreeBusyTimes(email, workWindow)
   if (buffers[0] > 0 || buffers[1] > 0) {
-    busyTimes = busyTimes.map(b => {
+    busyTimes = busyTimes.map((b) => {
       b.start.setMinutes(b.start.getMinutes() - buffers[0])
       b.end.setMinutes(b.end.getMinutes() + buffers[1])
       return b
@@ -110,26 +107,25 @@ function isNotBusy(busyTimes, proposedEvent, officeHours) {
     //verify start is not during busy or before/after office hours
     if (
       (proposedEvent.start.getTime() >= busyTime.start.getTime() &&
-            proposedEvent.start.getTime() < busyTime.end.getTime()) ||
-        proposedEvent.start.getTime() < officeHours.start.getTime() ||
-        proposedEvent.start.getTime() > officeHours.end.getTime()
+        proposedEvent.start.getTime() < busyTime.end.getTime()) ||
+      proposedEvent.start.getTime() < officeHours.start.getTime() ||
+      proposedEvent.start.getTime() > officeHours.end.getTime()
     ) {
       return false
     }
     //verify end is not during busy or after office hours
     if (
       (proposedEvent.end.getTime() > busyTime.start.getTime() &&
-            proposedEvent.end.getTime() <= busyTime.end.getTime()) ||
-        proposedEvent.end.getTime() > officeHours.end.getTime()
+        proposedEvent.end.getTime() <= busyTime.end.getTime()) ||
+      proposedEvent.end.getTime() > officeHours.end.getTime()
     ) {
       return false
     }
     //verify not busy during proposed event
     if (
       (busyTime.start.getTime() >= proposedEvent.start.getTime() &&
-            busyTime.start.getTime() < proposedEvent.end.getTime()) ||
-        (busyTime.end.getTime() > proposedEvent.start.getTime() &&
-            busyTime.end.getTime() <= proposedEvent.end.getTime())
+        busyTime.start.getTime() < proposedEvent.end.getTime()) ||
+      (busyTime.end.getTime() > proposedEvent.start.getTime() && busyTime.end.getTime() <= proposedEvent.end.getTime())
     ) {
       return false
     }

--- a/src/backend/PeopleFunctions.js
+++ b/src/backend/PeopleFunctions.js
@@ -1,0 +1,15 @@
+function getProfileByEmail(email) {
+  const person = People.People.searchDirectoryPeople({
+    query: email,
+    readMask: 'names,photos,organizations',
+    sources: ['DIRECTORY_SOURCE_TYPE_DOMAIN_PROFILE'],
+  }).people[0]
+
+  const { photos, organizations, names } = person
+
+  return {
+    name: names?.[0]?.displayName || email,
+    photo: photos?.[0]?.url,
+    title: organizations?.[0]?.title,
+  }
+}

--- a/src/backend/SheetFunctions.js
+++ b/src/backend/SheetFunctions.js
@@ -9,10 +9,9 @@ function getMeetingDetails(meetingId) {
 }
 
 function getRandomHost(meeting) {
-  const host =
-    typeof meeting.hosts === 'string' ? meeting.hosts : meeting.hosts[Math.floor(Math.random() * meeting.hosts.length)]
-
-  return mapObject(hosts, host)
+  return typeof meeting.hosts === 'string'
+    ? meeting.hosts
+    : meeting.hosts[Math.floor(Math.random() * meeting.hosts.length)]
 }
 
 function getMeetingHost(hostId) {

--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -281,9 +281,7 @@ function generateRequestorForm(timeBlock) {
         $('#scheduleEventButton').attr('disabled', true).addClass('disabled')
 
         google.script.run
-          .withSuccessHandler(() =>
-            showSuccessMark(requestorName.value, meetingSettings.displayName, requestorEmail.value)
-          )
+          .withSuccessHandler(() => showSuccessMark(requestorName.value, $('#host__name').text(), requestorEmail.value))
           .scheduleEvent(meetingSettings, timeBlock, requestorEmail.value)
       }
     })

--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -12,11 +12,7 @@ let currentYear = today.getFullYear()
 let selectedDay
 let selectedTime
 let meetingSettings = {
-  title: '',
-  time: 0,
   duration: 0,
-  type: 'default',
-  host: {},
 }
 
 const weekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
@@ -46,17 +42,31 @@ function fetchMeetingInfo(location) {
   const { parameter } = location
 
   google.script.run
-    .withSuccessHandler(updateSettings)
+    .withSuccessHandler(setMeetingInfo)
     .withFailureHandler((error) => console.error(error))
     .getMeetingInfo(parameter.meetingType ?? 'default')
 }
 
-function updateSettings(newSettings) {
+function setMeetingInfo(newSettings) {
   meetingSettings = newSettings
 
   $('#meetingType').empty().removeClass('skeleton').append(newSettings.title)
   $('#meetingDuration').empty().removeClass('skeleton').append(`${newSettings.duration} min`)
-  $('#interviewer').empty().removeClass('skeleton').append(newSettings.displayName)
+
+  google.script.run
+    .withSuccessHandler(setMeetingHostInfo)
+    .withFailureHandler((error) => console.error(error))
+    .getProfileByEmail(newSettings.host)
+}
+
+function setMeetingHostInfo(hostInfo) {
+  const { name, photo, title } = hostInfo
+
+  $('#host__name').empty().removeClass('skeleton').append(name)
+  $('#host__title').empty().removeClass('skeleton').append(title)
+
+  if (photo) $('#host__photo').empty().removeClass('skeleton').attr('src', photo)
+  else $('#host__photo').remove()
 }
 
 function generateCalendarContent(monthInt, yearInt) {
@@ -303,7 +313,13 @@ function generateInfoBlock() {
     })
 
   infoBlock.append(`
-    <h4 id="interviewer" class="info interviewer skeleton"></h4>
+    <div id="host__wrap" class="host__wrap">
+      <image id="host__photo" class="host__photo skeleton"></image>
+      <div class="host">
+        <h4 id="host__name" class="host__name skeleton"></h4>
+        <h5 id="host__title" class="host__title skeleton"></h5>
+      </div>
+    </div>
     <h2 id="meetingType" class="meetingType skeleton"></h2>
     <div id="duration" class="info__section">
       ${getClockIcon()}

--- a/src/frontend/style.css
+++ b/src/frontend/style.css
@@ -379,8 +379,37 @@ button.disabled:hover {
   background: gray;
 }
 
-.interviewer {
+.host__wrap {
+  display: flex;
+  column-gap: 16px;
+}
+
+img.host__photo {
+  height: 42px;
+  width: 42px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.host__photo {
+  border: 1px solid lightgray;
+}
+
+.host {
+  display: flex;
+  flex-grow: 1;
+  flex-direction: column;
+  row-gap: 4px;
+}
+
+.host__name {
   min-height: 18px;
+  color: gray;
+}
+
+.host__title {
+  color: gray;
+  min-height: 16px;
 }
 
 .meetingType {


### PR DESCRIPTION
- Leverages the People Service to find the meeting host info by email and pull the display name, title, & profile picture.
  - This deprecates the need for the id & displayName columns from the meetingDB.hosts sheet.
  - **NOTE** In order to pull the profile picture, the member must set their Google account picture to be available publically.

relates to: #11 