### PR TITLE
fix: add skeleton loading to calendar to prevent mis-clicks

### DIFF
--- a/src/frontend/app.js
+++ b/src/frontend/app.js
@@ -53,6 +53,9 @@ function setMeetingInfo(newSettings) {
   $('#meetingType').empty().removeClass('skeleton').append(newSettings.title)
   $('#meetingDuration').empty().removeClass('skeleton').append(`${newSettings.duration} min`)
 
+  const { firstDayOfWeek, maxWeeks } = genCalendarData(currentMonth, currentYear)
+  generateDays(maxWeeks, currentYear, currentMonth, firstDayOfWeek)
+
   google.script.run
     .withSuccessHandler(setMeetingHostInfo)
     .withFailureHandler((error) => console.error(error))
@@ -70,7 +73,7 @@ function setMeetingHostInfo(hostInfo) {
 }
 
 function generateCalendarContent(monthInt, yearInt) {
-  const { firstDayOfWeek, maxWeeks } = genCalendarData(monthInt, yearInt)
+  const { maxWeeks } = genCalendarData(monthInt, yearInt)
 
   const calendar = $('#calendar')
   calendar.empty()
@@ -87,7 +90,21 @@ function generateCalendarContent(monthInt, yearInt) {
   calendar.append(`<div class="weekdays">${children}</div>`)
   calendar.append('<div id="calendar_weekdays" class="calendarWeekdays" />')
 
-  generateDays(maxWeeks, yearInt, monthInt, firstDayOfWeek)
+  generateCalendarSkeleton(maxWeeks)
+}
+
+function generateCalendarSkeleton(maxWeeks) {
+  const calendarWeekdays = $('#calendar_weekdays')
+
+  for (let i = 0; i < maxWeeks; i++) {
+    let children = ''
+
+    for (let j = 1; j <= 7; j++) {
+      children += '<div class="day__skeleton skeleton"></div>'
+    }
+
+    calendarWeekdays.append(`<div class="week week__skeleton">${children}</div>`)
+  }
 }
 
 function genCalendarData(month, year) {

--- a/src/frontend/style.css
+++ b/src/frontend/style.css
@@ -338,6 +338,16 @@ button.disabled:hover {
   cursor: default;
 }
 
+.week__skeleton {
+  justify-content: space-around;
+}
+
+div.day__skeleton {
+  height: 32px;
+  width: 32px;
+  border-radius: 50%;
+}
+
 .details__wrap {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
- Adds skeleton loading on the calendar to prevent miss-clicking a day before the host info returns.

relates to: #25 