### PR TITLE
chore: add deploy script to keep static url

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@
 
 To deploy locally, execute `npm run build:push`. This will bundle up everything in the /src folder and push it to the Google App Script with the ID in your .clasp.json.
 
+### Deploying a static release
+
+If you want to use a specific descriptor name, the script looks for `RELEASE_NAME` from the environment. If it is not set it will default to `schedul8r`. Running the following command will create a new deployment with the specific descriptor from above. If the deployment already exists then it will update the existing deployment with the latest code.
+
+```sh
+npm run deploy
+```
+
 # Configuring meetings
 
 Configuration takes place directly in a spreadsheet.

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "clean": "rm -rf dist",
-    "build:api": "cp ./src/appsscript.json dist/appsscript.json && cp -r ./src/backend/ dist/backend/",
-    "dev": "vite",
     "build": "npm run clean && vite build && npm run build:api",
+    "build:api": "cp ./src/appsscript.json dist/appsscript.json && cp -r ./src/backend/ dist/backend/",
     "build:push": "npm run build && clasp push",
+    "clean": "rm -rf dist",
+    "dev": "vite",
+    "deploy": "npm run build:push && ./scripts/deploy.sh",
     "lint:fix": "eslint src/. --fix",
     "preview": "vite preview"
   },

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# This updates a specific deployment so that if it referenced anywhere else it does not
+# need to be updated to the latest deployment id.
+# Path: scripts/update_release.sh
+
+release_name=${RELEASE_NAME:-"schedul8r"}
+deployment_id=$(clasp deployments | grep "$release_name" | awk -F' ' '{print $2}')
+
+if [ -z "$deployment_id" ]
+then
+  echo "Creating new deployment: $release_name"
+
+  clasp deploy -d "$release_name"
+else
+    echo "Updating existing deployment: $release_name"
+    
+    clasp deploy -i "$deployment_id" -d "$release_name"
+fi


### PR DESCRIPTION
- Adds bash script `scripts\deploy.sh` to simplify pushing changes to a specific deployment id

relates to: #30 